### PR TITLE
feat: 結果コピー＆SNS共有機能

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "@upstash/vector": "^1.2.2",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
+        "html2canvas-pro": "^2.0.2",
         "lucide-react": "^0.511.0",
         "next": "^15.3.3",
         "react": "^19.1.0",
@@ -2780,6 +2781,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/base64-arraybuffer": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-1.0.2.tgz",
+      "integrity": "sha512-I3yl4r9QB5ZRY3XuJVEPfc2XhZO6YweFPI+UovAzn+8/hb3oJ6lnysaFcjVpkCPfVWFUDvoZ8kmVDP7WyRtYtQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
     "node_modules/brace-expansion": {
       "version": "1.1.12",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
@@ -3028,6 +3038,15 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/css-line-break": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/css-line-break/-/css-line-break-2.1.0.tgz",
+      "integrity": "sha512-FHcKFCZcAha3LwfVBhCQbW2nCNbkZXn7KVUJcsT5/P8YmfsVja0FMPJr0B903j/E69HUphKiV9iQArX8SDYA4w==",
+      "license": "MIT",
+      "dependencies": {
+        "utrie": "^1.0.2"
       }
     },
     "node_modules/csstype": {
@@ -4412,6 +4431,19 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/html2canvas-pro": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html2canvas-pro/-/html2canvas-pro-2.0.2.tgz",
+      "integrity": "sha512-9G/t0XgCZWonLwL0JwI7su6NdbOPUY7Ur4Ihpp8+XMaW9ibA2nDXF181Jr6tm94k8lX6sthpaXB3XqEnsMd5Cw==",
+      "license": "MIT",
+      "dependencies": {
+        "css-line-break": "^2.1.0",
+        "text-segmentation": "^1.0.3"
+      },
+      "engines": {
+        "node": ">=16.0.0"
       }
     },
     "node_modules/ignore": {
@@ -7666,6 +7698,15 @@
         "url": "https://opencollective.com/webpack"
       }
     },
+    "node_modules/text-segmentation": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/text-segmentation/-/text-segmentation-1.0.3.tgz",
+      "integrity": "sha512-iOiPUo/BGnZ6+54OsWxZidGCsdU8YbE4PSpdPinp7DeMtUJNJBoJ/ouUSTJjHkh1KntHaltHl/gDs2FC4i5+Nw==",
+      "license": "MIT",
+      "dependencies": {
+        "utrie": "^1.0.2"
+      }
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.15",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
@@ -8078,6 +8119,15 @@
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/utrie": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/utrie/-/utrie-1.0.2.tgz",
+      "integrity": "sha512-1MLa5ouZiOmQzUbjbu9VmjLzn1QLXBhwpUa7kdLUQK+KQ5KA9I1vk5U4YHe/X2Ch7PYnJfWuWT+VbuxbGwljhw==",
+      "license": "MIT",
+      "dependencies": {
+        "base64-arraybuffer": "^1.0.2"
       }
     },
     "node_modules/vfile": {

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "@upstash/vector": "^1.2.2",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
+    "html2canvas-pro": "^2.0.2",
     "lucide-react": "^0.511.0",
     "next": "^15.3.3",
     "react": "^19.1.0",

--- a/src/components/ResultCard.tsx
+++ b/src/components/ResultCard.tsx
@@ -1,6 +1,8 @@
 "use client";
 
+import { useRef, useState, useCallback } from "react";
 import { match } from "ts-pattern";
+import html2canvas from "html2canvas-pro";
 import {
   Card,
   CardContent,
@@ -16,7 +18,12 @@ import {
   AlertCircle,
   Lightbulb,
   RotateCcw,
+  Copy,
+  Check,
+  Share2,
+  Download,
 } from "lucide-react";
+import { ShareCard } from "@/components/ShareCard";
 import type { EvaluationResult, EvaluationRank } from "@/types";
 
 type ResultCardProps = {
@@ -50,9 +57,104 @@ function getScoreColor(score: number): string {
   return "bg-text-sub";
 }
 
+function buildShareText(result: EvaluationResult): string {
+  return `【設計力テスト結果】
+スコア: ${result.totalScore}/100
+ランク: ${result.rank}
+
+技術選定力: ${result.scores.stackSelection}
+設計力: ${result.scores.architecture}
+データ設計: ${result.scores.dataDesign}
+非機能要件: ${result.scores.nonFunctional}
+運用・コスト: ${result.scores.operationCost}
+
+#設計力テスト`;
+}
+
 export function ResultCard({ result, onRetry }: ResultCardProps) {
+  const shareCardRef = useRef<HTMLDivElement>(null);
+  const [copied, setCopied] = useState(false);
+  const [generating, setGenerating] = useState(false);
+
+  const handleCopy = useCallback(async () => {
+    const text = buildShareText(result);
+    await navigator.clipboard.writeText(text);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  }, [result]);
+
+  const generateImage = useCallback(async (): Promise<HTMLCanvasElement | null> => {
+    if (!shareCardRef.current) return null;
+    setGenerating(true);
+    try {
+      const canvas = await html2canvas(shareCardRef.current, {
+        scale: 2,
+        backgroundColor: null,
+        useCORS: true,
+      });
+      return canvas;
+    } finally {
+      setGenerating(false);
+    }
+  }, []);
+
+  const handleDownloadImage = useCallback(async () => {
+    const canvas = await generateImage();
+    if (!canvas) return;
+    const link = document.createElement("a");
+    link.download = `設計力テスト_${result.totalScore}点_${result.rank}.png`;
+    link.href = canvas.toDataURL("image/png");
+    link.click();
+  }, [generateImage, result]);
+
+  const handleShareX = useCallback(async () => {
+    // 画像をダウンロード
+    const canvas = await generateImage();
+    if (canvas) {
+      const link = document.createElement("a");
+      link.download = `設計力テスト_${result.totalScore}点.png`;
+      link.href = canvas.toDataURL("image/png");
+      link.click();
+    }
+
+    // 少し待ってからX投稿画面を開く
+    setTimeout(() => {
+      const text = `設計力テスト結果: ${result.totalScore}点（${result.rank}）\n\nダウンロードした画像を添付してね！\n\n#設計力テスト`;
+      const url = `https://twitter.com/intent/tweet?text=${encodeURIComponent(text)}`;
+      window.open(url, "_blank", "noopener,noreferrer");
+    }, 500);
+  }, [result, generateImage]);
+
+  const handleNativeShare = useCallback(async () => {
+    const canvas = await generateImage();
+    if (!canvas) return;
+
+    canvas.toBlob(async (blob) => {
+      if (!blob) return;
+      const file = new File([blob], "設計力テスト結果.png", { type: "image/png" });
+      const shareData: ShareData = {
+        title: "設計力テスト結果",
+        text: buildShareText(result),
+        files: [file],
+      };
+
+      if (navigator.canShare?.(shareData)) {
+        await navigator.share(shareData);
+      } else {
+        const textOnly: ShareData = {
+          title: "設計力テスト結果",
+          text: buildShareText(result),
+        };
+        await navigator.share(textOnly);
+      }
+    }, "image/png");
+  }, [generateImage, result]);
+
   return (
     <div className="space-y-6 animate-fade-in">
+      {/* 画像生成用の非表示カード */}
+      <ShareCard ref={shareCardRef} result={result} />
+
       {/* スコアヘッダー */}
       <Card className="text-center">
         <CardHeader>
@@ -68,6 +170,54 @@ export function ResultCard({ result, onRetry }: ResultCardProps) {
           </CardTitle>
         </CardHeader>
       </Card>
+
+      {/* 共有ボタン */}
+      <div className="flex flex-wrap justify-center gap-2">
+        <Button
+          onClick={handleCopy}
+          variant="outline"
+          size="sm"
+          className="gap-1.5"
+        >
+          {copied ? (
+            <Check className="size-4 text-success" />
+          ) : (
+            <Copy className="size-4" />
+          )}
+          {copied ? "コピーしました" : "結果をコピー"}
+        </Button>
+        <Button
+          onClick={handleDownloadImage}
+          variant="outline"
+          size="sm"
+          className="gap-1.5"
+          disabled={generating}
+        >
+          <Download className="size-4" />
+          画像を保存
+        </Button>
+        <Button
+          onClick={handleShareX}
+          variant="outline"
+          size="sm"
+          className="gap-1.5"
+          disabled={generating}
+        >
+          𝕏 画像付きポスト
+        </Button>
+        {typeof navigator !== "undefined" && "share" in navigator && (
+          <Button
+            onClick={handleNativeShare}
+            variant="outline"
+            size="sm"
+            className="gap-1.5"
+            disabled={generating}
+          >
+            <Share2 className="size-4" />
+            共有
+          </Button>
+        )}
+      </div>
 
       {/* 5軸スコア */}
       <Card>

--- a/src/components/ShareCard.tsx
+++ b/src/components/ShareCard.tsx
@@ -1,0 +1,157 @@
+"use client";
+
+import { forwardRef } from "react";
+import { Trophy } from "lucide-react";
+import { match } from "ts-pattern";
+import type { EvaluationResult, EvaluationRank } from "@/types";
+
+type ShareCardProps = {
+  result: EvaluationResult;
+};
+
+const SCORE_LABELS = [
+  { key: "stackSelection", label: "技術選定力" },
+  { key: "architecture", label: "設計力" },
+  { key: "dataDesign", label: "データ設計" },
+  { key: "nonFunctional", label: "非機能要件" },
+  { key: "operationCost", label: "運用・コスト" },
+] as const;
+
+function getRankColor(rank: EvaluationRank): string {
+  return match(rank)
+    .with("チーフアーキテクト", () => "#F59E0B")
+    .with("リードアーキテクト", () => "#6366F1")
+    .with("シニア設計者", () => "#10B981")
+    .with("ミドル設計者", () => "#0EA5E9")
+    .with("ジュニア設計者", () => "#78716C")
+    .exhaustive();
+}
+
+function getScoreBarColor(score: number): string {
+  if (score >= 85) return "#F59E0B";
+  if (score >= 70) return "#6366F1";
+  if (score >= 50) return "#10B981";
+  if (score >= 30) return "#0EA5E9";
+  return "#78716C";
+}
+
+export const ShareCard = forwardRef<HTMLDivElement, ShareCardProps>(
+  ({ result }, ref) => {
+    const rankColor = getRankColor(result.rank);
+
+    return (
+      <div
+        ref={ref}
+        style={{
+          width: 600,
+          padding: 40,
+          background: "linear-gradient(135deg, #FAFAF9 0%, #EEF2FF 100%)",
+          fontFamily: '"Noto Sans JP", system-ui, sans-serif',
+          position: "absolute",
+          left: -9999,
+          top: -9999,
+        }}
+      >
+        {/* ヘッダー */}
+        <div style={{ textAlign: "center", marginBottom: 24 }}>
+          <div
+            style={{
+              fontSize: 14,
+              color: "#6366F1",
+              fontWeight: 600,
+              marginBottom: 8,
+            }}
+          >
+            エンジニア設計力テスト
+          </div>
+          <div
+            style={{
+              fontSize: 72,
+              fontWeight: 800,
+              color: "#6366F1",
+              lineHeight: 1,
+            }}
+          >
+            {result.totalScore}
+          </div>
+          <div
+            style={{
+              fontSize: 24,
+              fontWeight: 700,
+              color: rankColor,
+              marginTop: 8,
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "center",
+              gap: 8,
+            }}
+          >
+            <Trophy size={24} color={rankColor} />
+            {result.rank}
+          </div>
+        </div>
+
+        {/* スコアバー */}
+        <div
+          style={{
+            background: "#FFFFFF",
+            borderRadius: 12,
+            padding: 20,
+            border: "1px solid #E7E5E4",
+          }}
+        >
+          {SCORE_LABELS.map(({ key, label }) => {
+            const score = result.scores[key];
+            return (
+              <div key={key} style={{ marginBottom: 12 }}>
+                <div
+                  style={{
+                    display: "flex",
+                    justifyContent: "space-between",
+                    fontSize: 13,
+                    marginBottom: 4,
+                  }}
+                >
+                  <span style={{ fontWeight: 600, color: "#1C1917" }}>
+                    {label}
+                  </span>
+                  <span style={{ color: "#78716C" }}>{score}/100</span>
+                </div>
+                <div
+                  style={{
+                    height: 10,
+                    borderRadius: 5,
+                    background: "#E7E5E4",
+                    overflow: "hidden",
+                  }}
+                >
+                  <div
+                    style={{
+                      height: "100%",
+                      width: `${score}%`,
+                      borderRadius: 5,
+                      background: getScoreBarColor(score),
+                    }}
+                  />
+                </div>
+              </div>
+            );
+          })}
+        </div>
+
+        {/* フッター */}
+        <div
+          style={{
+            textAlign: "center",
+            marginTop: 20,
+            fontSize: 12,
+            color: "#78716C",
+          }}
+        >
+          設計力テスト by カリスマEM
+        </div>
+      </div>
+    );
+  }
+);
+ShareCard.displayName = "ShareCard";


### PR DESCRIPTION
## Summary
- 結果テキストをクリップボードにコピー
- シェアカード画像をPNGダウンロード
- X（Twitter）画像付きポスト（画像DL → 投稿画面で添付）
- Web Share API対応端末でネイティブ画像共有

## Test plan
- [ ] 「結果をコピー」でスコア・ランク・5軸がコピーされること
- [ ] 「画像を保存」でシェアカードPNGがダウンロードされること
- [ ] 「𝕏 画像付きポスト」で画像DL後にX投稿画面が開くこと
- [ ] モバイルで「共有」ボタンが表示され画像付き共有できること

🤖 Generated with [Claude Code](https://claude.com/claude-code)